### PR TITLE
Fix a stability issue and enable unselect all the menu.

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -576,6 +576,7 @@ public class BottomBar extends FrameLayout implements View.OnClickListener, View
     }
 
     private void selectTab(View tab, boolean animate) {
+        if(tab == null) return;
         tab.setTag(TAG_BOTTOM_BAR_VIEW_ACTIVE);
         ImageView icon = (ImageView) tab.findViewById(R.id.bb_bottom_bar_icon);
         TextView title = (TextView) tab.findViewById(R.id.bb_bottom_bar_title);
@@ -637,6 +638,7 @@ public class BottomBar extends FrameLayout implements View.OnClickListener, View
     }
 
     private void unselectTab(View tab, boolean animate) {
+        if(tab == null) return;
         tab.setTag(TAG_BOTTOM_BAR_VIEW_INACTIVE);
 
         ImageView icon = (ImageView) tab.findViewById(R.id.bb_bottom_bar_icon);


### PR DESCRIPTION
Hi,
If someone delivers an incorrect number(-1, or a number bigger than max menu items) into **selectTabAtPosition** will cause an **null pointer exception and crash**. 
Besides, if we avoid null pointer exception, it will be able to unselect or clear selections to implement unselect all at app's initialization stage.   

This pull request just makes it work, maybe it's a little tricky.
Need you help to review if we need to consider this case.   
Hope we have more chance to cooperate.
Thanks.
Best regards.
Kylin.