### PR TITLE
Removing application from the library manifest

### DIFF
--- a/bottom-bar/src/main/AndroidManifest.xml
+++ b/bottom-bar/src/main/AndroidManifest.xml
@@ -1,9 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.roughike.bottombar">
-
-    <application
-        android:label="@string/app_name">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
The library project should not contain an `application` element as there is no application included. This causes issues with the manifest merger when using this library with an app that has an `app_name` defined in the `application` element.

The other workaround is to use `tools:replace="android:label"`.
```
Manifest merger failed : Attribute application@label value=(XYZ) from AndroidManifest.xml:31:9-35 is also present at [com.roughike:bottom-bar:1.1.7] AndroidManifest.xml:11:18-50 value=(@string/app_name).
Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml:27:5-219:19 to override.
```