### PR TITLE
Interface to notify listeners when the current action is reselected

### DIFF
--- a/app/src/main/java/com/example/bottombar/sample/MainActivity.java
+++ b/app/src/main/java/com/example/bottombar/sample/MainActivity.java
@@ -3,9 +3,11 @@ package com.example.bottombar.sample;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
+import android.widget.Toast;
 
 import com.roughike.bottombar.BottomBar;
 import com.roughike.bottombar.BottomBarFragment;
+import com.roughike.bottombar.OnTabItemClickListener;
 
 public class MainActivity extends AppCompatActivity {
     private BottomBar mBottomBar;
@@ -31,6 +33,18 @@ public class MainActivity extends AppCompatActivity {
         mBottomBar.mapColorForTab(2, "#7B1FA2");
         mBottomBar.mapColorForTab(3, "#FF5252");
         mBottomBar.mapColorForTab(4, "#FF9800");
+
+        mBottomBar.setOnItemSelectedListener(new OnTabItemClickListener() {
+            @Override
+            public void onItemReSelected(int position) {
+                Toast.makeText(MainActivity.this, "Reselected", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onItemSelected(int position) {
+
+            }
+        });
     }
 
     @Override

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -878,23 +878,35 @@ public class BottomBar extends FrameLayout implements View.OnClickListener, View
         if (v.getTag().equals(TAG_BOTTOM_BAR_VIEW_INACTIVE)) {
             unselectTab(findViewWithTag(TAG_BOTTOM_BAR_VIEW_ACTIVE), true);
             selectTab(v, true);
-            updateSelectedTab(findItemPosition(v));
         }
+        updateSelectedTab(findItemPosition(v));
     }
 
     private void updateSelectedTab(int newPosition) {
+        final boolean canNotifyMenuListener = mMenuListener != null && mItems instanceof BottomBarTab[];
+        final boolean canNotifyListener = mListener != null;
+
         if (newPosition != mCurrentTabPosition) {
             handleBadgeVisibility(mCurrentTabPosition, newPosition);
             mCurrentTabPosition = newPosition;
+
+            if (canNotifyListener) {
+                mListener.onItemSelected(mCurrentTabPosition);
+            }
+
+            if (canNotifyMenuListener) {
+                mMenuListener.onMenuItemSelected(((BottomBarTab) mItems[mCurrentTabPosition]).id);
+            }
+
             updateCurrentFragment();
-        }
+        } else {
+            if (canNotifyListener && mListener instanceof OnTabItemClickListener) {
+                ((OnTabItemClickListener) mListener).onItemReSelected(mCurrentTabPosition);
+            }
 
-        if (mListener != null) {
-            mListener.onItemSelected(mCurrentTabPosition);
-        }
-
-        if (mMenuListener != null && mItems instanceof BottomBarTab[]) {
-            mMenuListener.onMenuItemSelected(((BottomBarTab) mItems[mCurrentTabPosition]).id);
+            if (canNotifyMenuListener && mMenuListener instanceof OnMenuTabItemClickListener) {
+                ((OnMenuTabItemClickListener) mMenuListener).onMenuItemReSelected(((BottomBarTab) mItems[mCurrentTabPosition]).id);
+            }
         }
     }
 

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -886,16 +886,15 @@ public class BottomBar extends FrameLayout implements View.OnClickListener, View
         if (newPosition != mCurrentTabPosition) {
             handleBadgeVisibility(mCurrentTabPosition, newPosition);
             mCurrentTabPosition = newPosition;
-
-            if (mListener != null) {
-                mListener.onItemSelected(mCurrentTabPosition);
-            }
-
-            if (mMenuListener != null && mItems instanceof BottomBarTab[]) {
-                mMenuListener.onMenuItemSelected(((BottomBarTab) mItems[mCurrentTabPosition]).id);
-            }
-
             updateCurrentFragment();
+        }
+
+        if (mListener != null) {
+            mListener.onItemSelected(mCurrentTabPosition);
+        }
+
+        if (mMenuListener != null && mItems instanceof BottomBarTab[]) {
+            mMenuListener.onMenuItemSelected(((BottomBarTab) mItems[mCurrentTabPosition]).id);
         }
     }
 

--- a/bottom-bar/src/main/java/com/roughike/bottombar/OnMenuTabItemClickListener.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/OnMenuTabItemClickListener.java
@@ -1,0 +1,30 @@
+package com.roughike.bottombar;
+
+import android.support.annotation.IdRes;
+
+/*
+ * BottomBar library for Android
+ * Copyright (c) 2016 Iiro Krankka (http://github.com/roughike).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public interface OnMenuTabItemClickListener extends OnMenuTabSelectedListener {
+    /**
+     * The method being called when currently visible {@link BottomBarTab} is
+     * reselected.
+     *
+     * @param menuItemId the new visible tab's id that
+     *                   was assigned in the menu xml resource file.
+     */
+    void onMenuItemReSelected(@IdRes int menuItemId);
+}

--- a/bottom-bar/src/main/java/com/roughike/bottombar/OnMenuTabSelectedListener.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/OnMenuTabSelectedListener.java
@@ -35,6 +35,11 @@ import android.support.annotation.IdRes;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * @deprecated Use {@link OnMenuTabItemClickListener} instead
+ */
+@Deprecated
 public interface OnMenuTabSelectedListener {
     /**
      * The method being called when currently visible {@link BottomBarTab} changes.

--- a/bottom-bar/src/main/java/com/roughike/bottombar/OnTabItemClickListener.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/OnTabItemClickListener.java
@@ -1,0 +1,28 @@
+package com.roughike.bottombar;
+
+/*
+ * BottomBar library for Android
+ * Copyright (c) 2016 Iiro Krankka (http://github.com/roughike).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public interface OnTabItemClickListener extends OnTabSelectedListener {
+    /**
+     * The method being called when currently visible {@link BottomBarTab} is
+     * reselected.
+     *
+     * @param position the currently selected {@link BottomBarTab}
+     */
+    void onItemReSelected(int position);
+}

--- a/bottom-bar/src/main/java/com/roughike/bottombar/OnTabSelectedListener.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/OnTabSelectedListener.java
@@ -16,6 +16,11 @@ package com.roughike.bottombar;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * @deprecated Use {@link OnTabItemClickListener} instead
+ */
+@Deprecated
 public interface OnTabSelectedListener {
     /**
      * The method being called when currently visible {@link BottomBarTab} changes.


### PR DESCRIPTION
First off, thank you for this amazing library and all the hard work that you have put in!

The [Material Behavior spec](https://www.google.com/design/spec/components/bottom-navigation.html#bottom-navigation-behavior) states the following:
* Tapping on the active action in the bottom navigation bar will navigate the user to the top of the view.

Currently, the listeners are only notified if `newPosition != mCurrentTabPosition` and so they are not notified if the user taps the active action. This PR makes a small change to notify the listeners in all cases