### PR TITLE
Set BottomBar height to 56dp

### DIFF
--- a/bottom-bar/src/main/res/values/styles.xml
+++ b/bottom-bar/src/main/res/values/styles.xml
@@ -5,9 +5,9 @@
         <item name="android:orientation">vertical</item>
         <item name="android:gravity">bottom|center_horizontal</item>
         <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_height">56dp</item>
         <item name="android:paddingTop">8dp</item>
-        <item name="android:paddingBottom">10dp</item>
+        <item name="android:paddingBottom">5dp</item>
         <item name="android:paddingLeft">12dp</item>
         <item name="android:paddingRight">12dp</item>
     </style>


### PR DESCRIPTION
The height of the bottom bar should be **56dp** according to the [Material Design Specs](https://www.google.com/design/spec/components/bottom-navigation.html#bottom-navigation-specs).
See #168 