### PR TITLE
remove the hard coding primary-color here

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/MiscUtils.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/MiscUtils.java
@@ -20,7 +20,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewAnimationUtils;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
 import android.widget.PopupMenu;
 import android.widget.TextView;
 
@@ -43,7 +42,7 @@ import android.widget.TextView;
 class MiscUtils {
     protected static int getColor(Context context, int color) {
         TypedValue tv = new TypedValue();
-        context.getTheme().resolveAttribute(R.attr.colorPrimary, tv, true);
+        context.getTheme().resolveAttribute(color, tv, true);
         return tv.data;
     }
 


### PR DESCRIPTION
Currently **MiscUtils.getColor** is only used in **BottomBar.init**

`mPrimaryColor = MiscUtils.getColor(getContext(), R.attr.colorPrimary);`

The hard coding '**R.attr.colorPrimary**' could be safely removed. :)