### PR TITLE
Fix animation bug when programmatically selecting tab (issue #214)

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -380,7 +380,7 @@ public class BottomBar extends FrameLayout implements View.OnClickListener, View
         selectTab(newTab, animate);
 
         updateSelectedTab(position);
-        shiftingMagic(oldTab, newTab, false);
+        shiftingMagic(oldTab, newTab, animate);
     }
 
     /**


### PR DESCRIPTION
Fixes issue #214.
In `selectTabAtPosition`, `shiftingMagic()` was always being called with `false` instead of using `animate` parameter