### PR TITLE
Break up setting of items from menu and setting of click listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         mBottomBar = BottomBar.attach(this, savedInstanceState);
-        mBottomBar.setItemsFromMenu(R.menu.bottombar_menu, new OnMenuTabClickListener() {
+        mBottomBar.setItems(R.menu.bottombar_menu);
+        mBottomBar.setOnMenuTabClickListener(new OnMenuTabClickListener() {
             @Override
             public void onMenuTabSelected(@IdRes int menuItemId) {
                 if (menuItemId == R.id.bottomBarItemOne) {

--- a/app/app.iml
+++ b/app/app.iml
@@ -82,6 +82,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
@@ -92,12 +93,17 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-vector-drawable/23.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />

--- a/app/src/main/java/com/example/bottombar/sample/MainActivity.java
+++ b/app/src/main/java/com/example/bottombar/sample/MainActivity.java
@@ -22,7 +22,8 @@ public class MainActivity extends AppCompatActivity {
         mMessageView = (TextView) findViewById(R.id.messageView);
 
         mBottomBar = BottomBar.attach(this, savedInstanceState);
-        mBottomBar.setItemsFromMenu(R.menu.bottombar_menu, new OnMenuTabClickListener() {
+        mBottomBar.setItems(R.menu.bottombar_menu);
+        mBottomBar.setOnMenuTabClickListener(new OnMenuTabClickListener() {
             @Override
             public void onMenuTabSelected(@IdRes int menuItemId) {
                 mMessageView.setText(getMessage(menuItemId, false));
@@ -78,5 +79,12 @@ public class MainActivity extends AppCompatActivity {
         // Necessary to restore the BottomBar's state, otherwise we would
         // lose the current tab on orientation change.
         mBottomBar.onSaveInstanceState(outState);
+    }
+
+    @Override
+    protected void onDestroy() {
+        mBottomBar.setOnMenuTabClickListener(null);
+        super.onDestroy();
+
     }
 }

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -380,6 +380,9 @@ public class BottomBar extends FrameLayout implements View.OnClickListener, View
      * Set a listener that gets fired when the selected tab changes, when the
      * tabs are created from an XML menu resource file.
      *
+     * Note: If listener is set after items are added to the BottomBar, onMenuTabSelected
+     * will be immediately called for the currently selected tab
+     *
      * @param listener a listener for monitoring changes in tab selection.
      */
     public void setOnMenuTabClickListener(@Nullable OnMenuTabClickListener listener) {

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.MenuRes;
+import android.support.annotation.Nullable;
 import android.support.annotation.StyleRes;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.content.ContextCompat;
@@ -299,9 +300,10 @@ public class BottomBar extends FrameLayout implements View.OnClickListener, View
     }
 
     /**
-     * Set tabs for this BottomBar. When setting more than 3 items,
-     * only the icons will show by default, but the selected item
-     * will have the text visible.
+     * Set items for this BottomBar.
+     *
+     * When setting more than 3 items, only the icons will show by
+     * default, but the selected item will have the text visible.
      *
      * @param bottomBarTabs an array of {@link BottomBarTab} objects.
      */
@@ -310,9 +312,23 @@ public class BottomBar extends FrameLayout implements View.OnClickListener, View
         mItems = bottomBarTabs;
         updateItems(mItems);
     }
+    /**
+     * Set items for this BottomBar from an XML menu resource file.
+     *
+     * When setting more than 3 items, only the icons will show by
+     * default, but the selected item will have the text visible.
+     *
+     * @param menuRes  the menu resource to inflate items from.
+     */
+    public void setItems(@MenuRes int menuRes) {
+        clearItems();
+        mItems = MiscUtils.inflateMenuFromResource((Activity) getContext(), menuRes);
+        updateItems(mItems);
+    }
 
     /**
-     * Deprecated. Use {@link #setItemsFromMenu(int, OnMenuTabClickListener)} instead.
+     * Deprecated. Use {@link #setItems(int)} and
+     * {@link #setOnMenuTabClickListener(OnMenuTabClickListener)}instead.
      */
     @Deprecated
     public void setItemsFromMenu(@MenuRes int menuRes, OnMenuTabSelectedListener listener) {
@@ -323,11 +339,10 @@ public class BottomBar extends FrameLayout implements View.OnClickListener, View
     }
 
     /**
-     * Set items from an XML menu resource file.
-     *
-     * @param menuRes  the menu resource to inflate items from.
-     * @param listener listener for tab change events.
+     * Deprecated. Use {@link #setItems(int)} and
+     * {@link #setOnMenuTabClickListener(OnMenuTabClickListener)}instead.
      */
+    @Deprecated
     public void setItemsFromMenu(@MenuRes int menuRes, OnMenuTabClickListener listener) {
         clearItems();
         mItems = MiscUtils.inflateMenuFromResource((Activity) getContext(), menuRes);
@@ -358,6 +373,21 @@ public class BottomBar extends FrameLayout implements View.OnClickListener, View
 
         if (mItems != null && mItems.length > 0) {
             listener.onTabSelected(mCurrentTabPosition);
+        }
+    }
+
+    /**
+     * Set a listener that gets fired when the selected tab changes, when the
+     * tabs are created from an XML menu resource file.
+     *
+     * @param listener a listener for monitoring changes in tab selection.
+     */
+    public void setOnMenuTabClickListener(@Nullable OnMenuTabClickListener listener) {
+        mMenuListener = listener;
+
+        if (mMenuListener != null && mItems != null && mItems.length > 0
+                && mItems instanceof BottomBarTab[]) {
+            listener.onMenuTabSelected(((BottomBarTab) mItems[mCurrentTabPosition]).id);
         }
     }
 


### PR DESCRIPTION
In this PR, I deprecated the existing method that sets both the menu items from XML and the click listener at the same time. I think this is better for a number of reasons:

1. This allows the listener to be nulled out. This clears the path for creating a binding for the click listener that can be unsubscribed from, in the pattern of Jake Wharton's RxBinding library.
2. The API of BottomBar now more closely follows other widgets that inflate items from XML, such as the toolbar, where menu inflation and listener management are separate operations.