### PR TITLE
Fix selection/unselection when using badges

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarBadge.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarBadge.java
@@ -179,6 +179,7 @@ public class BottomBarBadge extends TextView {
         parent.removeView(tabToAddTo);
 
         container.setTag(tabToAddTo.getTag());
+        tabToAddTo.setTag(null);
         container.addView(tabToAddTo);
         container.addView(this);
 


### PR DESCRIPTION
When using badges, an extra FrameLayout is inserted as the container
for each tab. This container inherits the tag of the pre-badge tab view,
but the tag is not reset on the pre-badge tab view. This causes selection
and unselection of tabs to fail because findViewWithTag will erroneously
find the now obsolete tab views when searching for active tabs, resulting
in multiple tabs being visually selected when changing tabs.

By clearing the tag of the old (now inner) view when putting it in the new
tab container, we can ensure that findViewWithTag will only find relevant
views.

This fixes #266.