### PR TITLE
Add OnMenuTabLongClickListener for detecting long click over tabs

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -32,10 +32,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
-
 import com.roughike.bottombar.scrollsweetness.BottomNavigationBehavior;
-
 import java.util.HashMap;
 
 /*
@@ -98,6 +95,7 @@ public class BottomBar extends RelativeLayout implements View.OnClickListener, V
 
     private Object mListener;
     private Object mMenuListener;
+    private Object mMenuLongClickListener;
 
     private int mCurrentTabPosition;
     private boolean mIsShiftingMode;
@@ -396,6 +394,10 @@ public class BottomBar extends RelativeLayout implements View.OnClickListener, V
                 && mItems instanceof BottomBarTab[]) {
             listener.onMenuTabSelected(((BottomBarTab) mItems[mCurrentTabPosition]).id);
         }
+    }
+
+    public void setOnMenuTabLongClickListener(@Nullable OnMenuTabLongClickListener listener) {
+        mMenuLongClickListener = listener;
     }
 
     /**
@@ -1195,10 +1197,12 @@ public class BottomBar extends RelativeLayout implements View.OnClickListener, V
     }
 
     private boolean handleLongClick(View v) {
-        if ((mIsShiftingMode || mIsTabletMode) && v.getTag().equals(TAG_BOTTOM_BAR_VIEW_INACTIVE)) {
-            Toast.makeText(mContext, mItems[findItemPosition(v)].getTitle(mContext), Toast.LENGTH_SHORT).show();
+        if (mMenuLongClickListener == null) {
+            return true;
         }
 
+        boolean isActiveTabLongClicked = TAG_BOTTOM_BAR_VIEW_ACTIVE.equals(v.getTag());
+        ((OnMenuTabLongClickListener) mMenuLongClickListener).onMenuTabLongClicked(v.getId(), isActiveTabLongClicked);
         return true;
     }
 

--- a/bottom-bar/src/main/java/com/roughike/bottombar/OnMenuTabLongClickListener.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/OnMenuTabLongClickListener.java
@@ -1,0 +1,33 @@
+package com.roughike.bottombar;
+
+import android.support.annotation.IdRes;
+
+/*
+ * BottomBar library for Android
+ * Copyright (c) 2016 Iiro Krankka (http://github.com/roughike).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public interface OnMenuTabLongClickListener {
+
+    /**
+     * The method being called when {@link BottomBarTab} is long clicked.
+     *
+     * This listener is fired whenever {@link BottomBarTab} is long clicked.
+     *
+     * @param menuItemId the tab's id that was long clicked.
+     * @param isActiveTabLongClicked whether the active tab is long clicked.
+     *
+     */
+    void onMenuTabLongClicked(@IdRes int menuItemId, boolean isActiveTabLongClicked);
+}


### PR DESCRIPTION
closes #176

@roughike 

Hi, first of all, thank you for providing us such an amazing library!
I am developing my personal app using this library and I faced a situation where I want to detect when the user `OnLongClick`s tabs, so I have made this PR as an experiment or kind of a "start-out" to meet other developers' needs as well. 
## Done

All I did was adding `OnMenuTabLongClickListener` interface and its setter to `BottomBar` class. I have not written any javadocs for `setOnMenuTabLongClickListener` yet so I made this PR `WIP`; **I would really love if you have time to take a look at this PR and we can have share what we think about this (code or maybe a way of approaching the issue.. perhaps?)**

So, whenever you are free, can you check this PR?

Thanks!
## Related issue(s)

 This may be related to the issue: https://github.com/roughike/BottomBar/issues/176
