### PR TITLE
Update outdated method name in error output to help debugging

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -490,7 +490,7 @@ public class BottomBar extends RelativeLayout implements View.OnClickListener, V
     public void useFixedMode() {
         if (mItems != null) {
             throw new UnsupportedOperationException("This BottomBar already has items! " +
-                    "You must call the forceFixedMode() method before specifying any items.");
+                    "You must call the useFixedMode() method before specifying any items.");
         }
 
         mMaxFixedTabCount = -1;


### PR DESCRIPTION
forceFixedMode() is no longer exist and will not work, however this is still reference in the console output when people trying to use force title in tab bar. This update the reference in the output with the new method name.