### PR TITLE
Switch to support PopupMenu for vector drawables

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/MiscUtils.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/MiscUtils.java
@@ -13,6 +13,7 @@ import android.support.annotation.MenuRes;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPropertyAnimatorCompat;
 import android.support.v4.view.ViewPropertyAnimatorListenerAdapter;
+import android.support.v7.widget.PopupMenu;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.Menu;
@@ -20,7 +21,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewAnimationUtils;
 import android.view.ViewGroup;
-import android.widget.PopupMenu;
 import android.widget.TextView;
 
 /*


### PR DESCRIPTION
Replacing the stock PopupMenu with the support one allows automatic support for vector drawable for API < 21.