### PR TITLE
Remove unnecessary theme config code that cause app crash before API 21

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,10 +21,7 @@
         <activity android:name=".FiveColorChangingTabsActivity" />
         <activity android:name=".ThreeTabsQRActivity" />
         <activity android:name=".BadgeActivity" />
-        <activity
-            android:name=".CustomColorActivity"
-            android:label="@string/title_activity_custom_color"
-            android:theme="@style/AppTheme.NoActionBar"></activity>
+        <activity android:name=".CustomColorActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,9 +1,0 @@
-<resources>
-
-    <style name="AppTheme.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-    </style>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,5 +15,4 @@ Mauris sed libero. Suspendisse facilisis nulla in lacinia laoreet, lorem velit a
 Nam molestie nec tortor. Donec placerat leo sit amet velit. Vestibulum id justo ut vitae massa. Proin in dolor mauris consequat aliquam. Donec ipsum, vestibulum ullamcorper venenatis augue. Aliquam tempus nisi in auctor vulputate, erat felis pellentesque augue nec, pellentesque lectus justo nec erat. Aliquam et nisl. Quisque sit amet dolor in justo pretium condimentum.
 
 Vivamus placerat lacus vel vehicula scelerisque, dui enim adipiscing lacus sit amet sagittis, libero enim vitae mi. In neque magna posuere, euismod ac tincidunt tempor est. Ut suscipit nisi eu purus. Proin ut pede mauris eget ipsum. Integer vel quam nunc commodo consequat. Integer ac eros eu tellus dignissim viverra. Maecenas erat aliquam erat volutpat. Ut venenatis ipsum quis turpis. Integer cursus scelerisque lorem. Sed nec mauris id quam blandit consequat. Cras nibh mi hendrerit vitae, dapibus et aliquam et magna. Nulla vitae elit. Mauris consectetuer odio vitae augue.</string>
-    <string name="title_activity_custom_color">CustomColorActivity</string>
 </resources>


### PR DESCRIPTION
There is no theme style `AppTheme.NoActionbar` in `style.xml` file, then causing app crash on devices before API 21. Changing the activity's theme back to `AppTheme` is an easy and clean solution.
