### PR TITLE
mInActiveColor init value

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -963,6 +963,7 @@ public class BottomBar extends RelativeLayout implements View.OnClickListener, V
         mTabAlpha = alpha;
         mWhiteColor = activeColor;
         mPrimaryColor = backgroundColor;
+        mInActiveColor = ContextCompat.getColor(context, R.color.bb_inActiveBottomBarItemColor);
         init(context, null, 0, 0);
     }
 
@@ -993,15 +994,7 @@ public class BottomBar extends RelativeLayout implements View.OnClickListener, V
             mPrimaryColor = MiscUtils.getColor(getContext(), R.attr.colorPrimary);
             mInActiveColor = ContextCompat.getColor(getContext(), R.color.bb_inActiveBottomBarItemColor);
         }
-
-        //mWhiteColor = ContextCompat.getColor(getContext(), R.color.white);
-        //mPrimaryColor = MiscUtils.getColor(getContext(), R.attr.colorPrimary);
-        //mInActiveColor = ContextCompat.getColor(getContext(), R.color.bb_inActiveBottomBarItemColor);
-
-
-        //mWhiteColor = Color.parseColor("#000000");
-        //mPrimaryColor = Color.parseColor("#555555");
-        //mInActiveColor = Color.parseColor("#ffffff");
+        
 
         mScreenWidth = MiscUtils.getScreenWidth(mContext);
         mTenDp = MiscUtils.dpToPixel(mContext, 10);


### PR DESCRIPTION
Null pointer exception fix. The reason is mInActiveColor member is not being initialized (mInActiveColor=null) when the below constructor is called
      BottomBar(Context context, int backgroundColor, int activeColor, float alpha)

later (in unselectTab() ) the mInActiveColor is being used which causing the exception below :

`E/AndroidRuntime: FATAL EXCEPTION: main
                                                   Process: com.example.bottombar.sample, PID: 25740
                                                   java.lang.RuntimeException: Unable to start activity ComponentInfo{com.example.bottombar.sample/com.example.bottombar.sample.CustomColorActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.Integer.intValue()' on a null object reference
                                                       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2325)
                                                       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2387)
                                                       at android.app.ActivityThread.access$800(ActivityThread.java:151)
                                                       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1303)
                                                       at android.os.Handler.dispatchMessage(Handler.java:102)
                                                       at android.os.Looper.loop(Looper.java:135)
                                                       at android.app.ActivityThread.main(ActivityThread.java:5254)
                                                       at java.lang.reflect.Method.invoke(Native Method)
                                                       at java.lang.reflect.Method.invoke(Method.java:372)
                                                       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
                                                       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
                                                    Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.Integer.intValue()' on a null object reference
                                                       at com.roughike.bottombar.BottomBar.unselectTab(BottomBar.java:1555)
                                                       at com.roughike.bottombar.BottomBar.updateItems(BottomBar.java:1358)
                                                       at com.roughike.bottombar.BottomBar.setItems(BottomBar.java:343)
                                                       at com.example.bottombar.sample.CustomColorActivity.onCreate(CustomColorActivity.java:36)
                                                       at android.app.Activity.performCreate(Activity.java:5990)
...` 
