### PR TITLE
Add a attempt select event

### DIFF
--- a/app/src/main/java/com/example/bottombar/sample/CustomColorActivity.java
+++ b/app/src/main/java/com/example/bottombar/sample/CustomColorActivity.java
@@ -37,6 +37,11 @@ public class CustomColorActivity extends AppCompatActivity {
 
         mBottomBar.setOnMenuTabClickListener(new OnMenuTabClickListener() {
             @Override
+            public boolean onAttemptSelectMenuTab(@IdRes int menuItemId) {
+                return true;
+            }
+
+            @Override
             public void onMenuTabSelected(@IdRes int menuItemId) {
                 mMessageView.setText(TabMessage.get(menuItemId, false));
             }

--- a/app/src/main/java/com/example/bottombar/sample/FiveColorChangingTabsActivity.java
+++ b/app/src/main/java/com/example/bottombar/sample/FiveColorChangingTabsActivity.java
@@ -29,6 +29,11 @@ public class FiveColorChangingTabsActivity extends AppCompatActivity {
         mBottomBar.setItems(R.menu.bottombar_menu);
         mBottomBar.setOnMenuTabClickListener(new OnMenuTabClickListener() {
             @Override
+            public boolean onAttemptSelectMenuTab(@IdRes int menuItemId) {
+                return true;
+            }
+
+            @Override
             public void onMenuTabSelected(@IdRes int menuItemId) {
                 mMessageView.setText(TabMessage.get(menuItemId, false));
             }

--- a/app/src/main/java/com/example/bottombar/sample/ThreeTabsActivity.java
+++ b/app/src/main/java/com/example/bottombar/sample/ThreeTabsActivity.java
@@ -28,6 +28,11 @@ public class ThreeTabsActivity extends Activity {
         mBottomBar.setItems(R.menu.bottombar_menu_three_items);
         mBottomBar.setOnMenuTabClickListener(new OnMenuTabClickListener() {
             @Override
+            public boolean onAttemptSelectMenuTab(@IdRes int menuItemId) {
+                return true;
+            }
+
+            @Override
             public void onMenuTabSelected(@IdRes int menuItemId) {
                 mMessageView.setText(TabMessage.get(menuItemId, false));
             }

--- a/app/src/main/java/com/example/bottombar/sample/ThreeTabsQRActivity.java
+++ b/app/src/main/java/com/example/bottombar/sample/ThreeTabsQRActivity.java
@@ -28,6 +28,11 @@ public class ThreeTabsQRActivity extends AppCompatActivity {
         // from ThreeTabsActivity on how to use it.
         mBottomBar.setOnMenuTabClickListener(new OnMenuTabClickListener() {
             @Override
+            public boolean onAttemptSelectMenuTab(@IdRes int menuItemId) {
+                return true;
+            }
+
+            @Override
             public void onMenuTabSelected(@IdRes int menuItemId) {
 
             }

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -1150,6 +1150,17 @@ public class BottomBar extends RelativeLayout implements View.OnClickListener, V
     }
 
     private void handleClick(View v) {
+        int position = findItemPosition(v);
+        if (mMenuListener != null) {
+            if (!attemptSelectMenuTab(mMenuListener, ((BottomBarTab) mItems[position]).id)) {
+                return;
+            }
+        }
+        if (mListener != null) {
+            if (!attemptSelectRegularTab(mListener, position)) {
+                return;
+            }
+        }
         if (v.getTag().equals(TAG_BOTTOM_BAR_VIEW_INACTIVE)) {
             View oldTab = findViewWithTag(TAG_BOTTOM_BAR_VIEW_ACTIVE);
 
@@ -1158,7 +1169,7 @@ public class BottomBar extends RelativeLayout implements View.OnClickListener, V
 
             shiftingMagic(oldTab, v, true);
         }
-        updateSelectedTab(findItemPosition(v));
+        updateSelectedTab(position);
     }
 
     private void shiftingMagic(View oldTab, View newTab, boolean animate) {
@@ -1209,6 +1220,22 @@ public class BottomBar extends RelativeLayout implements View.OnClickListener, V
                 notifyMenuListener(mMenuListener, true, ((BottomBarTab) mItems[mCurrentTabPosition]).id);
             }
         }
+    }
+
+    private boolean attemptSelectRegularTab(Object listener, int position) {
+        if (listener instanceof OnTabClickListener) {
+            OnTabClickListener onTabClickListener = (OnTabClickListener) listener;
+            return onTabClickListener.onAttemptSelectTab(position);
+        }
+        return true;
+    }
+
+    private boolean attemptSelectMenuTab(Object listener, int position) {
+        if (listener instanceof OnMenuTabClickListener) {
+            OnMenuTabClickListener onMenuClickListener = (OnMenuTabClickListener) listener;
+            return onMenuClickListener.onAttemptSelectMenuTab(position);
+        }
+        return true;
     }
 
     @SuppressWarnings("deprecation")

--- a/bottom-bar/src/main/java/com/roughike/bottombar/OnMenuTabClickListener.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/OnMenuTabClickListener.java
@@ -1,6 +1,7 @@
 package com.roughike.bottombar;
 
 import android.support.annotation.IdRes;
+import android.support.annotation.IntDef;
 
 /*
  * BottomBar library for Android
@@ -19,6 +20,19 @@ import android.support.annotation.IdRes;
  * limitations under the License.
  */
 public interface OnMenuTabClickListener {
+    /**
+     * The method being called when user trying to change the currently visible
+     * {@link BottomBarTab}.
+     *
+     * This listener is fired after user click on a tab and before the selected
+     * tab really changed. Return true if this menu is selectable, false if it's
+     * not.
+     *
+     * @param menuItemId the new visible tab's id that
+     *                   was assigned in the menu xml resource file.
+     * @return if this tab selectable.
+     */
+    boolean onAttemptSelectMenuTab(@IdRes int menuItemId);
     /**
      * The method being called when currently visible {@link BottomBarTab} changes.
      *

--- a/bottom-bar/src/main/java/com/roughike/bottombar/OnTabClickListener.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/OnTabClickListener.java
@@ -19,6 +19,19 @@ package com.roughike.bottombar;
 
 public interface OnTabClickListener {
     /**
+     * The method being called when user trying to change the currently visible
+     * {@link BottomBarTab}.
+     *
+     * This listener is fired after user click on a tab and before the selected
+     * tab really changed. Return true if this menu is selectable, false if it's
+     * not.
+     *
+     * @param position the new visible {@link BottomBarTab}
+     *
+     * @return if this tab selectable.
+     */
+    boolean onAttemptSelectTab(int position);
+    /**
      * The method being called when currently visible {@link BottomBarTab} changes.
      *
      * This listener is fired for the first time after the items have been set and


### PR DESCRIPTION
Some times we'd like to have a check before really select a tab, for example, we have a user info tab, after user click on it, if there's a logged in user, just select the tab, otherwise it's not allowed to select that tab, show a login page may be more proper.

So I add this `onAttemptSelectMenuTab` interface, we can do that kind of check there, return true if the tab is selectable, false if it's not.

Hope this helps.
