### PR TITLE
Don't load tabs if no tab resource is set

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -107,7 +107,9 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     public BottomBar(Context context, AttributeSet attrs) {
         super(context, attrs);
         init(context, attrs);
-        setItems(tabXmlResource);
+        if (tabXmlResource != 0) {
+            setItems(tabXmlResource);
+        }
     }
 
     private void init(Context context, AttributeSet attrs) {


### PR DESCRIPTION
When called with `0`, `setItems` throws an error, causing an `InflationException`.
