### PR TITLE
Apply badge state restoration on the view itself

### DIFF
--- a/app/src/main/java/com/example/bottombar/sample/BadgeActivity.java
+++ b/app/src/main/java/com/example/bottombar/sample/BadgeActivity.java
@@ -17,6 +17,7 @@ import com.roughike.bottombar.OnTabSelectListener;
  */
 public class BadgeActivity extends AppCompatActivity {
     private TextView messageView;
+    private BottomBar bottomBar;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -25,7 +26,7 @@ public class BadgeActivity extends AppCompatActivity {
 
         messageView = (TextView) findViewById(R.id.messageView);
 
-        final BottomBar bottomBar = (BottomBar) findViewById(R.id.bottomBar);
+        bottomBar = (BottomBar) findViewById(R.id.bottomBar);
         bottomBar.setOnTabSelectListener(new OnTabSelectListener() {
             @Override
             public void onTabSelected(@IdRes int tabId) {
@@ -39,7 +40,11 @@ public class BadgeActivity extends AppCompatActivity {
                 Toast.makeText(getApplicationContext(), TabMessage.get(tabId, true), Toast.LENGTH_LONG).show();
             }
         });
+    }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
         BottomBarTab nearby = bottomBar.getTabWithId(R.id.tab_nearby);
         nearby.setBadgeCount(5);
     }

--- a/bottom-bar/src/androidTest/java/com/roughike/bottombar/BadgeTest.java
+++ b/bottom-bar/src/androidTest/java/com/roughike/bottombar/BadgeTest.java
@@ -1,12 +1,11 @@
 package com.roughike.bottombar;
 
-import android.os.Bundle;
+import android.os.Parcelable;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.annotation.UiThreadTest;
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,12 +74,9 @@ public class BadgeTest {
         nearby.setBadgeCount(1);
         assertEquals(1, nearby.badge.getCount());
 
-
-        int tabIndex = nearby.getIndexInTabContainer();
-        Bundle savedInstanceState = new Bundle();
-        savedInstanceState.putInt(BottomBarBadge.STATE_COUNT + tabIndex, 2);
-        nearby.badge.restoreState(savedInstanceState, tabIndex);
-
+        nearby.badge.setCount(2);
+        Parcelable state = nearby.badge.onSaveInstanceState();
+        nearby.badge.onRestoreInstanceState(state);
         assertEquals(2, nearby.badge.getCount());
     }
 

--- a/bottom-bar/src/androidTest/java/com/roughike/bottombar/BottomBarTabTest.java
+++ b/bottom-bar/src/androidTest/java/com/roughike/bottombar/BottomBarTabTest.java
@@ -1,6 +1,5 @@
 package com.roughike.bottombar;
 
-import android.os.Bundle;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.widget.FrameLayout;
@@ -51,13 +50,7 @@ public class BottomBarTabTest {
         tab.setIndexInContainer(69);
         assertEquals(69, tab.getIndexInTabContainer());
 
-        Bundle savedState = (Bundle) tab.onSaveInstanceState();
-        assertEquals(5, savedState.getInt(BottomBarBadge.STATE_COUNT + 69));
-
         tab.setBadgeCount(9);
         assertEquals(9, tab.badge.getCount());
-
-        tab.onRestoreInstanceState(savedState);
-        assertEquals(5, tab.badge.getCount());
     }
 }

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarBadge.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarBadge.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.ShapeDrawable;
 import android.os.Build;
-import android.os.Bundle;
-import android.support.annotation.VisibleForTesting;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.AppCompatImageView;
 import android.view.Gravity;
@@ -31,8 +31,6 @@ import android.widget.TextView;
  * limitations under the License.
  */
 class BottomBarBadge extends TextView {
-    @VisibleForTesting
-    static final String STATE_COUNT = "STATE_BADGE_COUNT_FOR_TAB_";
 
     private int count;
     private boolean isVisible = false;
@@ -176,13 +174,53 @@ class BottomBarBadge extends TextView {
         }
     }
 
-    Bundle saveState(int tabIndex) {
-        Bundle state = new Bundle();
-        state.putInt(STATE_COUNT + tabIndex, count);
-        return state;
+    @Override
+    public Parcelable onSaveInstanceState() {
+        Parcelable superState = super.onSaveInstanceState();
+        SavedState ss = new SavedState(superState);
+        ss.savedCount = this.count;
+        return ss;
     }
 
-    void restoreState(Bundle bundle, int tabIndex) {
-        setCount(bundle.getInt(STATE_COUNT + tabIndex, count));
+    @Override
+    public void onRestoreInstanceState(Parcelable state) {
+        if (!(state instanceof SavedState)) {
+            super.onRestoreInstanceState(state);
+            return;
+        }
+        SavedState ss = (SavedState) state;
+        super.onRestoreInstanceState(ss.getSuperState());
+        this.count = ss.savedCount;
+        setCount(count);
+    }
+
+    static class SavedState extends BaseSavedState {
+        int savedCount;
+
+        SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        private SavedState(Parcel in) {
+            super(in);
+            this.savedCount = in.readInt();
+        }
+
+        @Override
+        public void writeToParcel(Parcel out, int flags) {
+            super.writeToParcel(out, flags);
+            out.writeInt(this.savedCount);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR =
+                new Parcelable.Creator<SavedState>() {
+                    public SavedState createFromParcel(Parcel in) {
+                        return new SavedState(in);
+                    }
+
+                    public SavedState[] newArray(int size) {
+                        return new SavedState[size];
+                    }
+                };
     }
 }

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
@@ -7,8 +7,6 @@ import android.animation.ValueAnimator;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.os.Build;
-import android.os.Bundle;
-import android.os.Parcelable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.view.ViewCompat;
@@ -531,28 +529,6 @@ public class BottomBarTab extends LinearLayout {
 
         ViewCompat.setScaleX(titleView, scale);
         ViewCompat.setScaleY(titleView, scale);
-    }
-
-    @Override
-    public Parcelable onSaveInstanceState() {
-        if (badge != null) {
-            Bundle bundle = badge.saveState(indexInContainer);
-            bundle.putParcelable("superstate", super.onSaveInstanceState());
-            return bundle;
-        }
-
-        return super.onSaveInstanceState();
-    }
-
-    @Override
-    public void onRestoreInstanceState(Parcelable state) {
-        if (badge != null && state instanceof Bundle) {
-            Bundle bundle = (Bundle) state;
-            badge.restoreState(bundle, indexInContainer);
-
-            state = bundle.getParcelable("superstate");
-        }
-        super.onRestoreInstanceState(state);
     }
 
     public static class Config {


### PR DESCRIPTION
## What?

If you try to use a badge after a restore instance state, you receive an error that the view state was improperly restored.

## Reproduction steps

In the BadgeActivity, move the `setBadgeCount()` call into `onResume()`, and then rotate the device. You should receive this error:

```
         AndroidRuntime  E  FATAL EXCEPTION: main
                         E  Process: com.example.bottombar.sample, PID: 22353
                         E  java.lang.RuntimeException: Unable to start activity ComponentInfo{com.example.bottombar.sample/co
                            m.example.bottombar.sample.BadgeActivity}: java.lang.IllegalArgumentException: Wrong state class,
                            expecting View State but received class android.os.Bundle instead. This usually happens when two v
                            iews of different type have the same id in the same hierarchy. This view's id is id/tab_nearby. Ma
                            ke sure other views do not use the same id.
                         E      at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2416)
                         E      at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476)
                         E      at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4077)
                         E      at android.app.ActivityThread.-wrap15(ActivityThread.java)
                         E      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1350)
                         E      at android.os.Handler.dispatchMessage(Handler.java:102)
                         E      at android.os.Looper.loop(Looper.java:148)
                         E      at android.app.ActivityThread.main(ActivityThread.java:5417)
                         E      at java.lang.reflect.Method.invoke(Native Method)
                         E      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
                         E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
                         E  Caused by: java.lang.IllegalArgumentException: Wrong state class, expecting View State but receive
                            d class android.os.Bundle instead. This usually happens when two views of different type have the
                            same id in the same hierarchy. This view's id is id/tab_nearby. Make sure other views do not use t
                            he same id.
                         E      at android.view.View.onRestoreInstanceState(View.java:14771)
                         E      at com.roughike.bottombar.BottomBarTab.onRestoreInstanceState(BottomBarTab.java:555)
                         E      at android.view.View.dispatchRestoreInstanceState(View.java:14746)
                         E      at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3121)
                         E      at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3127)
                         E      at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3127)
                         E      at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3127)
                         E      at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3127)
                         E      at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3127)
                         E      at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3127)
                         E      at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3127)
                         E      at android.view.View.restoreHierarchyState(View.java:14724)
                         E      at com.android.internal.policy.PhoneWindow.restoreHierarchyState(PhoneWindow.java:2035)
                         E      at android.app.Activity.onRestoreInstanceState(Activity.java:1004)
                         E      at android.app.Activity.performRestoreInstanceState(Activity.java:959)
                         E      at android.app.Instrumentation.callActivityOnRestoreInstanceState(Instrumentation.java:1163)
                         E      at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2389)
                         E      ... 10 more
```

This is happening because the view state is not being restored on the custom view itself.

## How to fix

This PR implements the solution proposed by this [Stack Overflow answer](http://stackoverflow.com/a/3542895/409695). Modified unit tests to work with the new changes as well.

You can test this by running the PR, opening the badge activity, and rotating the screen. It should no longer exhibit the crash.