### PR TITLE
tabs redraw width based on view not screen

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -99,6 +99,9 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     private boolean shyHeightAlreadyCalculated;
     private boolean navBarAccountedHeightCalculated;
 
+    private List<BottomBarTab> mBottomBarItems;
+    private BottomBarTab[] tabViews;
+
     public BottomBar(Context context) {
         super(context);
         init(context, null);
@@ -295,14 +298,27 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
             index++;
         }
 
+        mBottomBarItems = bottomBarItems;
+        tabViews = viewsToAdd;
+
         if (!isTabletMode) {
             resizeTabsToCorrectSizes(bottomBarItems, viewsToAdd);
         }
     }
 
     private void resizeTabsToCorrectSizes(List<BottomBarTab> bottomBarItems, BottomBarTab[] viewsToAdd) {
+        if (tabContainer.getChildCount() != 0) {
+            tabContainer.removeAllViews();
+        }
+
+        int viewWidth = MiscUtils.pixelToDp(getContext(), getWidth());
+
+        if (viewWidth <= 0) {
+            viewWidth = screenWidth;
+        }
+
         int proposedItemWidth = Math.min(
-                MiscUtils.dpToPixel(getContext(), screenWidth / bottomBarItems.size()),
+                MiscUtils.dpToPixel(getContext(), viewWidth / bottomBarItems.size()),
                 maxFixedItemWidth
         );
 
@@ -530,6 +546,10 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         super.onLayout(changed, left, top, right, bottom);
 
         if (changed) {
+            if (!isTabletMode) {
+                resizeTabsToCorrectSizes(mBottomBarItems, tabViews);
+            }
+
             updateTitleBottomPadding();
 
             if (isShy()) {

--- a/bottom-bar/src/main/java/com/roughike/bottombar/MiscUtils.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/MiscUtils.java
@@ -50,6 +50,18 @@ class MiscUtils {
     }
 
     /**
+     * Converts pixels to dps just as well.
+     *
+     * @param context the Context for getting the resources
+     * @param px      dimension in pixels
+     * @return dimension in dps
+     */
+    protected static int pixelToDp(Context context, int px) {
+        DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+        return Math.round(px / (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT));
+    }
+
+    /**
      * Returns screen width.
      *
      * @param context Context to get resources and device specific display metrics


### PR DESCRIPTION
This resizes tabs according to the width of the parent view rather than the screen width. So for example, you can have a bottom tab bar on one side of a split view (master-detail), if you want.
