### PR TITLE
Fixed setting items programatically

### DIFF
--- a/app/src/main/java/com/example/bottombar/sample/ThreeTabsActivity.java
+++ b/app/src/main/java/com/example/bottombar/sample/ThreeTabsActivity.java
@@ -25,6 +25,7 @@ public class ThreeTabsActivity extends Activity {
         messageView = (TextView) findViewById(R.id.messageView);
 
         BottomBar bottomBar = (BottomBar) findViewById(R.id.bottomBar);
+        bottomBar.setItems(R.xml.bottombar_tabs_three);
         bottomBar.setOnTabSelectListener(new OnTabSelectListener() {
             @Override
             public void onTabSelected(@IdRes int tabId) {

--- a/app/src/main/res/layout/activity_three_tabs.xml
+++ b/app/src/main/res/layout/activity_three_tabs.xml
@@ -16,7 +16,6 @@
         android:id="@+id/bottomBar"
         android:layout_width="match_parent"
         android:layout_height="60dp"
-        android:layout_alignParentBottom="true"
-        app:bb_tabXmlResource="@xml/bottombar_tabs_three" />
+        android:layout_alignParentBottom="true"/>
 
 </RelativeLayout>

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -107,15 +107,15 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     public BottomBar(Context context, AttributeSet attrs) {
         super(context, attrs);
         init(context, attrs);
-        if (tabXmlResource != 0) {
-            setItems(tabXmlResource);
-        }
     }
 
     private void init(Context context, AttributeSet attrs) {
         populateAttributes(context, attrs);
         initializeViews();
         determineInitialBackgroundColor();
+        if (tabXmlResource != 0) {
+            setItems(tabXmlResource);
+        }
     }
 
     private void populateAttributes(Context context, AttributeSet attrs) {

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -107,7 +107,9 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     public BottomBar(Context context, AttributeSet attrs) {
         super(context, attrs);
         init(context, attrs);
-        setItems(tabXmlResource);
+        if (tabXmlResource != 0) {
+            setItems(tabXmlResource);
+        }
     }
 
     private void init(Context context, AttributeSet attrs) {
@@ -256,6 +258,7 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         int index = 0;
         int biggestWidth = 0;
 
+        tabContainer.removeAllViews();
         BottomBarTab[] viewsToAdd = new BottomBarTab[bottomBarItems.size()];
 
         for (BottomBarTab bottomBarTab : bottomBarItems) {


### PR DESCRIPTION
The changes in the PR fix a couple of issues with regards to setting the tab items programmatically while setting up the layout in XML.
- It removes the requirement to have the tabs defined in the XML layout
- If the user sets the tab items programmatically, the previously rendered tabs are cleared before the new list is rendered.
