### PR TITLE
Add way to change bar programmatically without triggering listeners

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -432,6 +432,10 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
      * @param animate should the tab change be animated or not.
      */
     public void selectTabAtPosition(int position, boolean animate) {
+        selectTabAtPosition(position, animate, true);
+    }
+
+    public void selectTabAtPosition(int position, boolean animate, boolean triggerListeners) {
         if (position > getTabCount() - 1 || position < 0) {
             throw new IndexOutOfBoundsException("Can't select tab at position " +
                     position + ". This BottomBar has no items at that position.");
@@ -443,7 +447,11 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         oldTab.deselect(animate);
         newTab.select(animate);
 
-        updateSelectedTab(position);
+        if(triggerListeners)
+            updateSelectedTab(position);
+        else
+            currentTabPosition = position;
+
         shiftingMagic(oldTab, newTab, animate);
         handleBackgroundColorChange(newTab, animate);
     }


### PR DESCRIPTION
Currently the easiest way to change without triggering a listener is something like:
```
bottomBar.setOnTabSelectListener(null);
bottomBar.selectTabAtPosition(position, true);
bottomBar.setOnTabSelectListener(this, false);
```
This changeset exposes a way to avoid triggering listeners through the most likely call the user is already making. Previous API should behave the same, only users invoking this with triggerListeners (false) explicitly will see the difference.

Note: `updateSelectedTab` basically just calls listeners and updates currentTabPositon. I would have added triggerListeners there too, but it seems to be more like a setCurrentTabAndFireEvents :) so why nto just set current tab.

Fixes #499