### PR TITLE
Adding OnTabShouldSelectListener

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -90,6 +90,7 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     private int inActiveShiftingItemWidth;
     private int activeShiftingItemWidth;
 
+    private OnTabShouldSelectListener onTabShouldSelectListener;
     private OnTabSelectListener onTabSelectListener;
     private OnTabReselectListener onTabReselectListener;
 
@@ -347,6 +348,15 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
 
             tabView.requestLayout();
         }
+    }
+
+    /**
+     * Set a listener that gets fired when the selected tab is about to change.
+     *
+     * @param listener a listener for potentially interrupting changes in tab selection.
+     */
+    public void setOnTabShouldSelectListener(@Nullable OnTabShouldSelectListener listener) {
+        onTabShouldSelectListener = listener;
     }
 
     /**
@@ -764,6 +774,12 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     private void handleClick(View v) {
         BottomBarTab oldTab = getCurrentTab();
         BottomBarTab newTab = (BottomBarTab) v;
+
+        if (onTabShouldSelectListener != null) {
+            if (!onTabShouldSelectListener.onTabShouldSelect(oldTab.getId(), newTab.getId())) {
+                return;
+            }
+        }
 
         oldTab.deselect(true);
         newTab.select(true);

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -90,7 +90,7 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     private int inActiveShiftingItemWidth;
     private int activeShiftingItemWidth;
 
-    private OnTabShouldSelectListener onTabShouldSelectListener;
+    private TabOverrideListener tabOverrideListener;
     private OnTabSelectListener onTabSelectListener;
     private OnTabReselectListener onTabReselectListener;
 
@@ -355,8 +355,8 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
      *
      * @param listener a listener for potentially interrupting changes in tab selection.
      */
-    public void setOnTabShouldSelectListener(@Nullable OnTabShouldSelectListener listener) {
-        onTabShouldSelectListener = listener;
+    public void setTabOverrideListener(@Nullable TabOverrideListener listener) {
+        tabOverrideListener = listener;
     }
 
     /**
@@ -775,8 +775,8 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         BottomBarTab oldTab = getCurrentTab();
         BottomBarTab newTab = (BottomBarTab) v;
 
-        if (onTabShouldSelectListener != null) {
-            if (!onTabShouldSelectListener.onTabShouldSelect(oldTab.getId(), newTab.getId())) {
+        if (tabOverrideListener != null) {
+            if (tabOverrideListener.shouldOverrideTabSelection(oldTab.getId(), newTab.getId())) {
                 return;
             }
         }

--- a/bottom-bar/src/main/java/com/roughike/bottombar/OnTabShouldSelectListener.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/OnTabShouldSelectListener.java
@@ -1,0 +1,32 @@
+package com.roughike.bottombar;
+
+import android.support.annotation.IdRes;
+
+/*
+ * BottomBar library for Android
+ * Copyright (c) 2016 Iiro Krankka (http://github.com/roughike).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public interface OnTabShouldSelectListener {
+    /**
+     * The method being called when currently visible {@link BottomBarTab} is about to change.
+     *
+     * This listener is fired when the current tab is about to change. This gives
+     * an opportunity to interrupt the tab change.
+     *
+     * @param oldTabId the currently visible {@link BottomBarTab}
+     * @param newTabId the {@link BottomBarTab} that will be switched to
+     */
+    boolean onTabShouldSelect(@IdRes int oldTabId, @IdRes int newTabId);
+}

--- a/bottom-bar/src/main/java/com/roughike/bottombar/TabOverrideListener.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/TabOverrideListener.java
@@ -18,7 +18,7 @@ import android.support.annotation.IdRes;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-public interface OnTabShouldSelectListener {
+public interface TabOverrideListener {
     /**
      * The method being called when currently visible {@link BottomBarTab} is about to change.
      *
@@ -27,6 +27,8 @@ public interface OnTabShouldSelectListener {
      *
      * @param oldTabId the currently visible {@link BottomBarTab}
      * @param newTabId the {@link BottomBarTab} that will be switched to
+     *
+     * @return true if you want to override/stop the tab change, false to continue as normal
      */
-    boolean onTabShouldSelect(@IdRes int oldTabId, @IdRes int newTabId);
+    boolean shouldOverrideTabSelection(@IdRes int oldTabId, @IdRes int newTabId);
 }


### PR DESCRIPTION
Adding a way to intercept tab selection.

**EDIT**

I've added an interface `OnTabShouldSelectListener` with a single method `boolean onTabShouldSelect(@IdRes int oldTabId, @IdRes int newTabId)`. The purpose of this is to be able to add logic to stop tab changes. There may be a better name for this interface and/or method. The `BottomBar` checks in `private void handleClick(View v)` for a non-null `onTabShouldSelectListener ` and calls out to it to see if it should proceed with the tab change. This technically intercepts both select and reselect. I could also break the interface into two different methods, or rename the interface to something more encompassing.

Our use case is that we want to warn the user of unsaved changes before they go (and then programmatically proceed with the tab change if they want to discard their unsaved changes).