### PR TITLE
fix for calculating width of tabs

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -324,7 +324,7 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         );
 
         inActiveShiftingItemWidth = (int) (proposedItemWidth * 0.9);
-        activeShiftingItemWidth = (int) (proposedItemWidth + (proposedItemWidth * (tabsToAdd.length * 0.1)));
+        activeShiftingItemWidth = (int) (proposedItemWidth + (proposedItemWidth * ((tabsToAdd.length - 1) * 0.1)));
         int height = Math.round(getContext().getResources().getDimension(R.dimen.bb_height));
 
         for (BottomBarTab tabView : tabsToAdd) {

--- a/bottom-bar/src/main/java/com/roughike/bottombar/MiscUtils.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/MiscUtils.java
@@ -43,7 +43,7 @@ class MiscUtils {
         DisplayMetrics metrics = resources.getDisplayMetrics();
 
         try {
-            return (int) (dp * (metrics.densityDpi / 160f));
+            return (int) (dp * metrics.density);
         } catch (NoSuchFieldError ignored) {
             return (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, metrics);
         }
@@ -58,7 +58,7 @@ class MiscUtils {
      */
     protected static int pixelToDp(Context context, int px) {
         DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
-        return Math.round(px / (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT));
+        return Math.round(px / displayMetrics.density);
     }
 
     /**


### PR DESCRIPTION
fixed faulty pixel to DP conversion, that caused first and last tab to go outside bounds of bar
fixed active tab width for active element in shifting mode