### PR TITLE
Add ability to keep badges visible even when the tab is selected

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -74,6 +74,7 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     private int inActiveTabColor;
     private int activeTabColor;
     private int badgeBackgroundColor;
+    private boolean hideBadgeWhenActive;
     private int titleTextAppearance;
     private Typeface titleTypeFace;
     private boolean showShadow;
@@ -148,6 +149,7 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
             inActiveTabColor = ta.getColor(R.styleable.BottomBar_bb_inActiveTabColor, defaultInActiveColor);
             activeTabColor = ta.getColor(R.styleable.BottomBar_bb_activeTabColor, defaultActiveColor);
             badgeBackgroundColor = ta.getColor(R.styleable.BottomBar_bb_badgeBackgroundColor, Color.RED);
+            hideBadgeWhenActive = ta.getBoolean(R.styleable.BottomBar_bb_badgeHidesWhenActive, true);
             titleTextAppearance = ta.getResourceId(R.styleable.BottomBar_bb_titleTextAppearance, 0);
             titleTypeFace = getTypeFaceFromAsset(ta.getString(R.styleable.BottomBar_bb_titleTypeFace));
             showShadow = ta.getBoolean(R.styleable.BottomBar_bb_showShadow, true);
@@ -254,6 +256,7 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
                 .activeTabColor(activeTabColor)
                 .barColorWhenSelected(defaultBackgroundColor)
                 .badgeBackgroundColor(badgeBackgroundColor)
+                .hideBadgeWhenSelected(hideBadgeWhenActive)
                 .titleTextAppearance(titleTextAppearance)
                 .titleTypeFace(titleTypeFace)
                 .build();
@@ -564,6 +567,19 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
             @Override
             public void update(BottomBarTab tab) {
                 tab.setBadgeBackgroundColor(badgeBackgroundColor);
+            }
+        });
+    }
+
+    /**
+     * Set background color for the badge.
+     */
+    public void setHideBadgeWhenActive(final boolean hideWhenSelected) {
+        hideBadgeWhenActive = hideWhenSelected;
+        batchPropertyApplier.applyToAllTabs(new BatchTabPropertyApplier.TabPropertyUpdater() {
+            @Override
+            public void update(BottomBarTab tab) {
+                tab.setBadgeHidesWhenSelected(hideWhenSelected);
             }
         });
     }

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
@@ -388,7 +388,7 @@ public class BottomBarTab extends LinearLayout {
             setAlphas(inActiveAlpha);
         }
 
-        if (!isShifting && badge != null && badgeHidesWhenSelected) {
+        if (!isShifting && badge != null && !badge.isVisible()) {
             badge.show();
         }
     }

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
@@ -46,32 +46,24 @@ public class BottomBarTab extends LinearLayout {
     private final int sixDps;
     private final int eightDps;
     private final int sixteenDps;
-
+    @VisibleForTesting
+    BottomBarBadge badge;
     private Type type = Type.FIXED;
     private int iconResId;
     private String title;
-
     private float inActiveAlpha;
     private float activeAlpha;
     private int inActiveColor;
     private int activeColor;
     private int barColorWhenSelected;
     private int badgeBackgroundColor;
-
+    private boolean badgeHidesWhenSelected;
     private AppCompatImageView iconView;
     private TextView titleView;
     private boolean isActive;
-
     private int indexInContainer;
-
-    @VisibleForTesting
-    BottomBarBadge badge;
     private int titleTextAppearanceResId;
     private Typeface titleTypeFace;
-
-    enum Type {
-        FIXED, SHIFTING, TABLET
-    }
 
     BottomBarTab(Context context) {
         super(context);
@@ -88,6 +80,7 @@ public class BottomBarTab extends LinearLayout {
         setActiveColor(config.activeTabColor);
         setBarColorWhenSelected(config.barColorWhenSelected);
         setBadgeBackgroundColor(config.badgeBackgroundColor);
+        setBadgeHidesWhenSelected(config.badgeHidesWhenSelected);
         setTitleTextAppearance(config.titleTextAppearance);
         setTitleTypeface(config.titleTypeFace);
     }
@@ -262,6 +255,10 @@ public class BottomBarTab extends LinearLayout {
         }
     }
 
+    public void setBadgeHidesWhenSelected(boolean hideWhenSelected) {
+        this.badgeHidesWhenSelected = hideWhenSelected;
+    }
+
     int getCurrentDisplayedIconColor() {
         Object tag = iconView.getTag();
 
@@ -332,14 +329,14 @@ public class BottomBarTab extends LinearLayout {
         iconView.setColorFilter(tint);
     }
 
+    public int getTitleTextAppearance() {
+        return titleTextAppearanceResId;
+    }
+
     @SuppressWarnings("deprecation")
     void setTitleTextAppearance(int resId) {
         this.titleTextAppearanceResId = resId;
         updateCustomTextAppearance();
-    }
-
-    public int getTitleTextAppearance() {
-        return titleTextAppearanceResId;
     }
 
     public void setTitleTypeface(Typeface typeface) {
@@ -366,7 +363,7 @@ public class BottomBarTab extends LinearLayout {
             setAlphas(activeAlpha);
         }
 
-        if (badge != null) {
+        if (badge != null && badgeHidesWhenSelected) {
             badge.hide();
         }
     }
@@ -391,7 +388,7 @@ public class BottomBarTab extends LinearLayout {
             setAlphas(inActiveAlpha);
         }
 
-        if (!isShifting && badge != null) {
+        if (!isShifting && badge != null && badgeHidesWhenSelected) {
             badge.show();
         }
     }
@@ -403,7 +400,7 @@ public class BottomBarTab extends LinearLayout {
         anim.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override
             public void onAnimationUpdate(ValueAnimator valueAnimator) {
-               setColors((Integer) valueAnimator.getAnimatedValue());
+                setColors((Integer) valueAnimator.getAnimatedValue());
             }
         });
 
@@ -577,6 +574,10 @@ public class BottomBarTab extends LinearLayout {
         setBadgeCount(previousBadgeCount);
     }
 
+    enum Type {
+        FIXED, SHIFTING, TABLET
+    }
+
     public static class Config {
         private final float inActiveTabAlpha;
         private final float activeTabAlpha;
@@ -586,6 +587,7 @@ public class BottomBarTab extends LinearLayout {
         private final int badgeBackgroundColor;
         private final int titleTextAppearance;
         private final Typeface titleTypeFace;
+        private boolean badgeHidesWhenSelected;
 
         private Config(Builder builder) {
             this.inActiveTabAlpha = builder.inActiveTabAlpha;
@@ -594,6 +596,7 @@ public class BottomBarTab extends LinearLayout {
             this.activeTabColor = builder.activeTabColor;
             this.barColorWhenSelected = builder.barColorWhenSelected;
             this.badgeBackgroundColor = builder.badgeBackgroundColor;
+            this.badgeHidesWhenSelected = builder.hidesBadgeWhenSelected;
             this.titleTextAppearance = builder.titleTextAppearance;
             this.titleTypeFace = builder.titleTypeFace;
         }
@@ -605,6 +608,7 @@ public class BottomBarTab extends LinearLayout {
             private int activeTabColor;
             private int barColorWhenSelected;
             private int badgeBackgroundColor;
+            private boolean hidesBadgeWhenSelected;
             private int titleTextAppearance;
             private Typeface titleTypeFace;
 
@@ -635,6 +639,11 @@ public class BottomBarTab extends LinearLayout {
 
             public Builder badgeBackgroundColor(@ColorInt int color) {
                 this.badgeBackgroundColor = color;
+                return this;
+            }
+
+            public Builder hideBadgeWhenSelected(boolean hide) {
+                this.hidesBadgeWhenSelected = hide;
                 return this;
             }
 

--- a/bottom-bar/src/main/res/values/attrs.xml
+++ b/bottom-bar/src/main/res/values/attrs.xml
@@ -13,6 +13,7 @@
         <attr name="bb_inActiveTabColor" format="color" />
         <attr name="bb_activeTabColor" format="color" />
         <attr name="bb_badgeBackgroundColor" format="color" />
+        <attr name="bb_badgeHidesWhenActive" format="boolean" />
         <attr name="bb_titleTextAppearance" format="reference" />
         <attr name="bb_titleTypeFace" format="string" />
         <attr name="bb_showShadow" format="boolean" />


### PR DESCRIPTION
This allows the possibility of keeping the badges visible when the tab is selected
this is a nice feature that existed before 2.0 and is preventing us from updating to the latest version