### PR TITLE
Allowing drawable selectors to change icon when tab is selected

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
@@ -371,6 +371,7 @@ public class BottomBarTab extends LinearLayout {
             setAlphas(activeAlpha);
         }
 
+        setSelected(true);
         if (badge != null && badgeHidesWhenActive) {
             badge.hide();
         }
@@ -396,6 +397,7 @@ public class BottomBarTab extends LinearLayout {
             setAlphas(inActiveAlpha);
         }
 
+        setSelected(false);
         if (!isShifting && badge != null && !badge.isVisible()) {
             badge.show();
         }


### PR DESCRIPTION
- Setting the "selected" state to true when the tab is active, and false otherwise

- This allows the use of DrawableSelectors in case you need to change the drawable when tab selected

