### PR TITLE
Show & Hide methods when on shy mode.

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -103,7 +103,7 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     private boolean isComingFromRestoredState;
     private boolean ignoreTabReselectionListener;
 
-    private Boolean pendingIsVisibleInShyMode;
+    private ShySettings shySettings;
     private boolean shyHeightAlreadyCalculated;
     private boolean navBarAccountedHeightCalculated;
 
@@ -217,8 +217,12 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
                 && NavbarUtils.shouldDrawBehindNavbar(getContext());
     }
 
-    private boolean isShy() {
+    boolean isShy() {
         return !isTabletMode && hasBehavior(BEHAVIOR_SHY);
+    }
+
+    boolean isShyHeightAlreadyCalculated() {
+        return shyHeightAlreadyCalculated;
     }
 
     private boolean hasBehavior(int behavior) {
@@ -396,46 +400,21 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     }
 
     /**
-     * Shows the BottomBar in shy mode, if it was hidden.
+     * Returns the settings specific for a shy BottomBar.
      *
-     * If this BottomBar is a shy one (with bb_behavior set to "shy"), this
-     * will show it with a translate animation.
-     *
-     * If this BottomBar is NOT shy, or if it's already visible, this will be
-     * a no-op.
+     * @throws UnsupportedOperationException, if this BottomBar is not shy.
      */
-    public void showInShyMode() {
-        toggleIsVisibleInShyMode(true);
-    }
-
-    /**
-     * Hides the BottomBar in shy mode, if it was visible.
-     *
-     * If this BottomBar is a shy one (with bb_behavior set to "shy"), this
-     * will hide it with a translate animation.
-     *
-     * If this BottomBar is NOT shy, or if it's already hidden, this will be
-     * a no-op.
-     */
-    public void hideInShyMode() {
-        toggleIsVisibleInShyMode(false);
-    }
-
-    private void toggleIsVisibleInShyMode(boolean visible) {
+    public ShySettings getShySettings() {
         if (!isShy()) {
-            return;
+            throw new UnsupportedOperationException("Tried to get shy settings for a " +
+                    "BottomBar that is not shy.");
         }
 
-        if (shyHeightAlreadyCalculated) {
-            BottomNavigationBehavior<BottomBar> behavior = BottomNavigationBehavior.from(this);
-
-            if (behavior != null) {
-                boolean isHidden = !visible;
-                behavior.setHidden(this, isHidden);
-            }
-        } else {
-            pendingIsVisibleInShyMode = true;
+        if (shySettings == null) {
+            shySettings = new ShySettings(this);
         }
+
+        return shySettings;
     }
 
     /**
@@ -806,16 +785,9 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
 
             if (height != 0) {
                 updateShyHeight(height);
-                updatePendingShyVisibility();
+                getShySettings().shyHeightCalculated();
                 shyHeightAlreadyCalculated = true;
             }
-        }
-    }
-
-    private void updatePendingShyVisibility() {
-        if (pendingIsVisibleInShyMode != null) {
-            toggleIsVisibleInShyMode(pendingIsVisibleInShyMode);
-            pendingIsVisibleInShyMode = null;
         }
     }
 

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -24,6 +24,7 @@ import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPropertyAnimatorListenerAdapter;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewAnimationUtils;
 import android.view.ViewGroup;
@@ -414,8 +415,8 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
      */
     public ShySettings getShySettings() {
         if (!isShy()) {
-            throw new UnsupportedOperationException("Tried to get shy settings for a " +
-                    "BottomBar that is not shy.");
+            Log.e("BottomBar", "Tried to get shy settings for a BottomBar " +
+                    "that is not shy.");
         }
 
         if (shySettings == null) {

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -427,11 +427,11 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         }
 
         if (shyHeightAlreadyCalculated) {
-            BottomNavigationBehavior<BottomBar> from = BottomNavigationBehavior.from(this);
+            BottomNavigationBehavior<BottomBar> behavior = BottomNavigationBehavior.from(this);
 
-            if (from != null) {
+            if (behavior != null) {
                 boolean isHidden = !visible;
-                from.setHidden(this, isHidden);
+                behavior.setHidden(this, isHidden);
             }
         } else {
             pendingIsVisibleInShyMode = true;

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomNavigationBehavior.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomNavigationBehavior.java
@@ -113,16 +113,20 @@ class BottomNavigationBehavior<V extends View> extends VerticalScrollingBehavior
 
     static <V extends View> BottomNavigationBehavior<V> from(@NonNull V view) {
         ViewGroup.LayoutParams params = view.getLayoutParams();
+
         if (!(params instanceof CoordinatorLayout.LayoutParams)) {
             throw new IllegalArgumentException("The view is not a child of CoordinatorLayout");
         }
+
         CoordinatorLayout.Behavior behavior = ((CoordinatorLayout.LayoutParams) params)
                 .getBehavior();
-        if (!(behavior instanceof BottomNavigationBehavior)) {
-            throw new IllegalArgumentException(
-                    "The view is not associated with BottomNavigationBehavior");
+
+        if (behavior instanceof BottomNavigationBehavior) {
+            // noinspection unchecked
+            return (BottomNavigationBehavior<V>) behavior;
         }
-        return (BottomNavigationBehavior<V>) behavior;
+
+        throw new IllegalArgumentException("The view is not associated with BottomNavigationBehavior");
     }
 
     private interface BottomNavigationWithSnackbar {

--- a/bottom-bar/src/main/java/com/roughike/bottombar/ShySettings.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/ShySettings.java
@@ -1,0 +1,55 @@
+package com.roughike.bottombar;
+
+/**
+ * Settings specific for a shy BottomBar.
+ */
+public class ShySettings {
+    private BottomBar bottomBar;
+    private Boolean pendingIsVisibleInShyMode;
+
+    ShySettings(BottomBar bottomBar) {
+        this.bottomBar = bottomBar;
+    }
+
+    void shyHeightCalculated() {
+        updatePendingShyVisibility();
+    }
+
+    /**
+     * Shows the BottomBar if it was hidden, with a translate animation.
+     */
+    public void showBar() {
+        toggleIsVisibleInShyMode(true);
+    }
+
+    /**
+     * Hides the BottomBar in if it was visible, with a translate animation.
+     */
+    public void hideBar() {
+        toggleIsVisibleInShyMode(false);
+    }
+
+    private void toggleIsVisibleInShyMode(boolean visible) {
+        if (!bottomBar.isShy()) {
+            return;
+        }
+
+        if (bottomBar.isShyHeightAlreadyCalculated()) {
+            BottomNavigationBehavior<BottomBar> behavior = BottomNavigationBehavior.from(bottomBar);
+
+            if (behavior != null) {
+                boolean isHidden = !visible;
+                behavior.setHidden(bottomBar, isHidden);
+            }
+        } else {
+            pendingIsVisibleInShyMode = true;
+        }
+    }
+
+    private void updatePendingShyVisibility() {
+        if (pendingIsVisibleInShyMode != null) {
+            toggleIsVisibleInShyMode(pendingIsVisibleInShyMode);
+            pendingIsVisibleInShyMode = null;
+        }
+    }
+}


### PR DESCRIPTION
This needs some input:

- Is the method naming on point? Could it be misinterpreted somehow?
- Do we want to support hide / show methods when NOT on shy mode? The layouts can be quite complex and I personally think hiding the regular (=not shy) BottomBars should probably be the user's job, as this is a regular view after all.