### PR TITLE
Fixed BottomNavigationBehavior does not trigger at the first scroll

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomNavigationBehavior.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomNavigationBehavior.java
@@ -65,6 +65,13 @@ class BottomNavigationBehavior<V extends View> extends VerticalScrollingBehavior
 
     @Override
     public void onDirectionNestedPreScroll(CoordinatorLayout coordinatorLayout, V child, View target, int dx, int dy, int[] consumed, @ScrollDirection int scrollDirection) {
+        if (scrollDirection == ScrollDirection.SCROLL_NONE) {
+            if (dy > 0) {
+                scrollDirection = ScrollDirection.SCROLL_DIRECTION_UP;
+            } else if (dy < 0) {
+                scrollDirection = ScrollDirection.SCROLL_DIRECTION_DOWN;
+            }
+        }
         handleDirection(child, scrollDirection);
     }
 


### PR DESCRIPTION
BottomNavigationBehavior does not trigger at the first scroll when used RecyclerView inside NestedScrollView.