### PR TITLE
Bumped Support Library to 25.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.3.1
+
+* [#749](https://github.com/roughike/BottomBar/pull/749): Quick fix for the issue where *bb_showShadow* set to false didn't have any effect. Thanks @yombunker!
+
 ### 2.3.0
 
 * [#713](https://github.com/roughike/BottomBar/pull/713): Ripple touch feedback for tabs!
@@ -11,6 +15,12 @@
 * [#712](https://github.com/roughike/BottomBar/pull/712): Data binding fixes.
 
 Thanks for @yombunker, @MarcRubio and @tushar-acharya for their contributions!
+
+### 2.2.0
+
+* Ability to change icons when the tabs are selected, using drawable selectors
+* Overriding tab selections is now supported, by using [TabSelectionInterceptor](https://github.com/roughike/BottomBar/blob/master/bottom-bar/src/main/java/com/roughike/bottombar/TabSelectionInterceptor.java)
+* Internal code quality improvements and small changes
 
 ### 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Nope. The minSDK version is **API level 11 (Honeycomb).**
 ## Gimme that Gradle sweetness, pls?
 
 ```groovy
-compile 'com.roughike:bottom-bar:2.3.0'
+compile 'com.roughike:bottom-bar:2.3.1'
 ```
 
 **Maven:**
@@ -37,7 +37,7 @@ compile 'com.roughike:bottom-bar:2.3.0'
 <dependency>
   <groupId>com.roughike</groupId>
   <artifactId>bottom-bar</artifactId>
-  <version>2.3.0</version>
+  <version>2.3.1</version>
   <type>pom</type>
 </dependency>
 ```

--- a/bottom-bar/build.gradle
+++ b/bottom-bar/build.gradle
@@ -14,7 +14,7 @@ ext {
     siteUrl = 'https://github.com/roughike/BottomBar'
     gitUrl = 'https://github.com/roughike/BottomBar.git'
 
-    libraryVersion = '2.3.0'
+    libraryVersion = '2.3.1'
 
     developerId = 'roughike'
     developerName = 'Iiro Krankka'

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -83,6 +83,7 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     private Typeface titleTypeFace;
     private boolean showShadow;
     private float shadowElevation;
+    private View shadowView;
 
     private View backgroundOverlay;
     private ViewGroup outerContainer;
@@ -153,7 +154,8 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         super.onAttachedToWindow();
 
         // This is so that in Pre-Lollipop devices there is a shadow BUT without pushing the content
-        if (showShadow) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP && showShadow && shadowView != null) {
+            shadowView.setVisibility(VISIBLE);
             ViewGroup.LayoutParams params = getLayoutParams();
             if (params instanceof MarginLayoutParams) {
                 MarginLayoutParams layoutParams = (MarginLayoutParams) params;
@@ -170,12 +172,14 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     private void init21(Context context) {
-        shadowElevation = getElevation();
-        shadowElevation = shadowElevation > 0
-                ? shadowElevation
-                : getResources().getDimensionPixelSize(R.dimen.bb_default_elevation);
-        setElevation(MiscUtils.dpToPixel(context, shadowElevation));
-        setOutlineProvider(ViewOutlineProvider.BOUNDS);
+        if (showShadow) {
+            shadowElevation = getElevation();
+            shadowElevation = shadowElevation > 0
+                    ? shadowElevation
+                    : getResources().getDimensionPixelSize(R.dimen.bb_default_elevation);
+            setElevation(MiscUtils.dpToPixel(context, shadowElevation));
+            setOutlineProvider(ViewOutlineProvider.BOUNDS);
+        }
     }
 
     private void populateAttributes(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
@@ -184,7 +188,8 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         tenDp = MiscUtils.dpToPixel(getContext(), 10);
         maxFixedItemWidth = MiscUtils.dpToPixel(getContext(), 168);
 
-        TypedArray ta = context.getTheme().obtainStyledAttributes(attrs, R.styleable.BottomBar, defStyleAttr, defStyleRes);
+        TypedArray ta = context.getTheme()
+                               .obtainStyledAttributes(attrs, R.styleable.BottomBar, defStyleAttr, defStyleRes);
 
         try {
             tabXmlResource = ta.getResourceId(R.styleable.BottomBar_bb_tabXmlResource, 0);
@@ -230,7 +235,9 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         return shyHeightAlreadyCalculated;
     }
 
-    private boolean isIconsOnlyMode() { return !isTabletMode && hasBehavior(BEHAVIOR_ICONS_ONLY); }
+    private boolean isIconsOnlyMode() {
+        return !isTabletMode && hasBehavior(BEHAVIOR_ICONS_ONLY);
+    }
 
     private boolean hasBehavior(int behavior) {
         return (behaviors | behavior) == behaviors;
@@ -260,6 +267,7 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         backgroundOverlay = rootView.findViewById(R.id.bb_bottom_bar_background_overlay);
         outerContainer = (ViewGroup) rootView.findViewById(R.id.bb_bottom_bar_outer_container);
         tabContainer = (ViewGroup) rootView.findViewById(R.id.bb_bottom_bar_item_container);
+        shadowView = findViewById(R.id.bb_bottom_bar_shadow);
     }
 
     private void determineInitialBackgroundColor() {
@@ -386,7 +394,8 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
 
         inActiveShiftingItemWidth = (int) (proposedItemWidth * 0.9);
         activeShiftingItemWidth = (int) (proposedItemWidth + (proposedItemWidth * ((tabsToAdd.length - 1) * 0.1)));
-        int height = Math.round(getContext().getResources().getDimension(R.dimen.bb_height));
+        int height = Math.round(getContext().getResources()
+                                            .getDimension(R.dimen.bb_height));
 
         for (BottomBarTab tabView : tabsToAdd) {
             ViewGroup.LayoutParams params = tabView.getLayoutParams();
@@ -925,7 +934,8 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
                 && longPressHintsEnabled;
 
         if (shouldShowHint) {
-            Toast.makeText(getContext(), longClickedTab.getTitle(), Toast.LENGTH_SHORT).show();
+            Toast.makeText(getContext(), longClickedTab.getTitle(), Toast.LENGTH_SHORT)
+                 .show();
         }
 
         return true;
@@ -1044,23 +1054,24 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     private void backgroundCrossfadeAnimation(final int newColor) {
         ViewCompat.setAlpha(backgroundOverlay, 0);
         ViewCompat.animate(backgroundOverlay)
-                .alpha(1)
-                .setListener(new ViewPropertyAnimatorListenerAdapter() {
-                    @Override
-                    public void onAnimationEnd(View view) {
-                        onEnd();
-                    }
+                  .alpha(1)
+                  .setListener(new ViewPropertyAnimatorListenerAdapter() {
+                      @Override
+                      public void onAnimationEnd(View view) {
+                          onEnd();
+                      }
 
-                    @Override
-                    public void onAnimationCancel(View view) {
-                        onEnd();
-                    }
+                      @Override
+                      public void onAnimationCancel(View view) {
+                          onEnd();
+                      }
 
-                    private void onEnd() {
-                        outerContainer.setBackgroundColor(newColor);
-                        backgroundOverlay.setVisibility(View.INVISIBLE);
-                        ViewCompat.setAlpha(backgroundOverlay, 1);
-                    }
-                }).start();
+                      private void onEnd() {
+                          outerContainer.setBackgroundColor(newColor);
+                          backgroundOverlay.setVisibility(View.INVISIBLE);
+                          ViewCompat.setAlpha(backgroundOverlay, 1);
+                      }
+                  })
+                  .start();
     }
 }

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
@@ -1,7 +1,5 @@
 package com.roughike.bottombar;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
 import android.animation.ArgbEvaluator;
 import android.animation.ValueAnimator;
 import android.content.Context;
@@ -493,15 +491,19 @@ public class BottomBarTab extends LinearLayout {
                 setLayoutParams(params);
             }
         });
-        animator.addListener(new AnimatorListenerAdapter() {
+
+        // Workaround to avoid using faulty onAnimationEnd() listener
+        postDelayed(new Runnable() {
             @Override
-            public void onAnimationEnd(Animator animation) {
+            public void run() {
                 if (!isActive && badge != null) {
+                    clearAnimation();
                     badge.adjustPositionAndSize(BottomBarTab.this);
                     badge.show();
                 }
             }
-        });
+        }, animator.getDuration());
+
         animator.start();
     }
 

--- a/bottom-bar/src/main/res/layout/bb_bottom_bar_item_container.xml
+++ b/bottom-bar/src/main/res/layout/bb_bottom_bar_item_container.xml
@@ -5,7 +5,8 @@
         android:id="@+id/bb_bottom_bar_shadow"
         android:layout_width="match_parent"
         android:layout_height="@dimen/bb_fake_shadow_height"
-        android:background="@drawable/bb_bottom_bar_top_shadow" />
+        android:background="@drawable/bb_bottom_bar_top_shadow"
+        android:visibility="gone"/>
 
     <FrameLayout
         android:id="@+id/bb_bottom_bar_outer_container"
@@ -16,14 +17,14 @@
             android:id="@+id/bb_bottom_bar_background_overlay"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="invisible" />
+            android:visibility="invisible"/>
 
         <LinearLayout
             android:id="@+id/bb_bottom_bar_item_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center"
-            android:orientation="horizontal" />
+            android:orientation="horizontal"/>
 
     </FrameLayout>
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
     buildToolsVersion = "25.0.2"
     minSdkVersion = 11
     targetSdkVersion = 25
-    supportLibraryVersion = "25.3.0"
+    supportLibraryVersion = "25.3.1"
 
     junitVersion = "4.12"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.4.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
As reported in #784, I updated `supportLibraryVersion` from `25.3.0` to `25.3.1`.

I used this local build with my project instead of release v2.3.1 and it builds correctly.

I run the `:bottom-bar` tests locally and all of them passed.