### PR TITLE
Consider onConfigurationChanged.

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -4,6 +4,7 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.Typeface;
@@ -885,6 +886,12 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
             int restoredPosition = savedInstanceState.getInt(STATE_CURRENT_SELECTED_TAB, currentTabPosition);
             selectTabAtPosition(restoredPosition, false);
         }
+    }
+
+    @Override
+    protected void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        screenWidth = MiscUtils.getScreenWidth(getContext());
     }
 
     @Override


### PR DESCRIPTION
# Purpose
For handling orientation changes.
Before this fix, each of tabs has too small size when the orientaion is changed.

# Reproduction steps

1. Handle the configuration change yourself

```xml
<activity android:name=".ThreeTabsActivity"
            android:configChanges="orientation|screenSize"/>
```

2. Start sample app with portrait screen orientation and change to landscape

# Images

|  | Portrait | Landscape |
|:-----------:|:-----------:|:------------:|
| Before | ![before_portrait](https://cloud.githubusercontent.com/assets/11682809/26619384/33dcfb60-4619-11e7-927e-08d9739b4604.png) | ![before_landscape](https://cloud.githubusercontent.com/assets/11682809/26619396/3c37d442-4619-11e7-8ba6-9643f0be5408.png) |
| After | Same to portrait orientation's | ![after_landscape](https://cloud.githubusercontent.com/assets/11682809/26619602/24b598bc-461a-11e7-870d-e5e833a8eae1.png) |