### PR TITLE
Optionally specify to format the badge text for large counts

### DIFF
--- a/app/src/main/java/com/example/bottombar/sample/BadgeActivity.java
+++ b/app/src/main/java/com/example/bottombar/sample/BadgeActivity.java
@@ -40,7 +40,14 @@ public class BadgeActivity extends AppCompatActivity {
             }
         });
 
+        BottomBarTab favorites = bottomBar.getTabWithId(R.id.tab_favorites);
+        favorites.setBadgeCount(1200);
+
         BottomBarTab nearby = bottomBar.getTabWithId(R.id.tab_nearby);
         nearby.setBadgeCount(5);
+
+        BottomBarTab friends = bottomBar.getTabWithId(R.id.tab_friends);
+        friends.setBadgeCount(1200, true);
+
     }
 }

--- a/bottom-bar/src/androidTest/java/com/roughike/bottombar/BadgeTest.java
+++ b/bottom-bar/src/androidTest/java/com/roughike/bottombar/BadgeTest.java
@@ -95,4 +95,15 @@ public class BadgeTest {
         assertNull(nearby.badge);
         assertEquals(bottomBar.findViewById(R.id.bb_bottom_bar_item_container), nearby.getOuterView());
     }
+
+    @Test
+    @UiThreadTest
+    public void badgeFormatTest() {
+        nearby.setBadgeCount(1200, true);
+        assertNotNull(nearby.badge);
+        assertEquals(nearby.badge.getText(), "1K");
+
+        nearby.setBadgeCount(0, true);
+        assertNull(nearby.badge);
+    }
 }

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarBadge.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarBadge.java
@@ -42,9 +42,13 @@ class BottomBarBadge extends TextView {
      *
      * @param count the value this Badge should show.
      */
-    void setCount(int count) {
+    void setCount(int count, boolean formatBadge) {
         this.count = count;
-        setText(String.valueOf(count));
+        if (formatBadge && count > 1000) {
+            setText(String.format(getResources().getString(R.string.badge_format), count / 1000));
+        } else {
+            setText(String.valueOf(count));
+        }
     }
 
     /**

--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
@@ -317,6 +317,10 @@ public class BottomBarTab extends LinearLayout {
     }
 
     public void setBadgeCount(int count) {
+        setBadgeCount(count, false);
+    }
+
+    public void setBadgeCount(int count, boolean formatBadge) {
         if (count <= 0) {
             if (badge != null) {
                 badge.removeFromTab(this);
@@ -331,7 +335,7 @@ public class BottomBarTab extends LinearLayout {
             badge.attachToTab(this, badgeBackgroundColor);
         }
 
-        badge.setCount(count);
+        badge.setCount(count, formatBadge);
 
         if (isActive && badgeHidesWhenActive) {
             badge.hide();

--- a/bottom-bar/src/main/res/values/strings.xml
+++ b/bottom-bar/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">BottomBar</string>
+    <string name="badge_format">%dK</string>
 </resources>


### PR DESCRIPTION
Overload a new function for BottomBarBadge.setCount to allow specifying if the badge text should be formatted (summarized) for large counts (1000~1999 to 1K, and so on) which reduces the length of badge text by 2 for large badges, resulting in a more appealing badge.
The default behavior for the setCount(int count) is not altered.