### PR TITLE
Show badge by default in setBadgeCount

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBarTab.java
@@ -335,6 +335,8 @@ public class BottomBarTab extends LinearLayout {
 
         if (isActive && badgeHidesWhenActive) {
             badge.hide();
+        } else {
+            badge.show();
         }
     }
 


### PR DESCRIPTION
We hit a situation where after calling `removeBadge` and creating a new badge, the visibility was set to hidden by default, thus not showing the badge. Just throwing this in to explicitly set the visibility if it is not active and configured to be hidden while active.