### PR TITLE
Fix: wrong getCurrentTabPosition value when called from OnTabSelectLi…

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -942,6 +942,8 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
     }
 
     private void updateSelectedTab(int newPosition) {
+        currentTabPosition = newPosition;
+        
         int newTabId = getTabAtPosition(newPosition).getId();
 
         if (newPosition != currentTabPosition) {
@@ -951,8 +953,6 @@ public class BottomBar extends LinearLayout implements View.OnClickListener, Vie
         } else if (onTabReselectListener != null && !ignoreTabReselectionListener) {
             onTabReselectListener.onTabReSelected(newTabId);
         }
-
-        currentTabPosition = newPosition;
 
         if (ignoreTabReselectionListener) {
             ignoreTabReselectionListener = false;


### PR DESCRIPTION
…stener

Fixes this:

bottomBar.setOnTabSelectListener { tabResId ->
    bottomBar.getCurrentTabPosition() // wrong value - I get the previous one not the current one
}